### PR TITLE
basePath fixed

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -66,19 +66,23 @@ const ForkMonkey = {
         this.showToast('🐵 ForkMonkey loaded!', 'success');
     },
 
+    getDevMode() {
+        const urlParams = new URLSearchParams(window.location.search);
+        return urlParams.get('dev') == 'true';
+    },
 
     /**
      * Load all static JSON data files
      */
     async loadAllData() {
         const files = [
-            ['dna', `monkey_data/dna.json`],
-            ['stats', `monkey_data/stats.json`],
-            ['history', `monkey_data/history.json`],
-            ['community', `community_data.json`],
-            ['leaderboard', `leaderboard.json`],
-            ['familyTree', `family_tree.json`],
-            ['networkStats', `network_stats.json`]
+            ['dna', `${this.getDevMode() ? '/../' : '' }monkey_data/dna.json`],
+            ['stats', `${this.getDevMode() ? '/../' : '' }monkey_data/stats.json`],
+            ['history', `${this.getDevMode() ? '/../' : '' }monkey_data/history.json`],
+            ['community', 'community_data.json'],
+            ['leaderboard', 'leaderboard.json'],
+            ['familyTree', 'family_tree.json'],
+            ['networkStats', 'network_stats.json']
         ];
 
         const results = await Promise.allSettled(
@@ -205,7 +209,7 @@ const ForkMonkey = {
         const frame = document.getElementById('monkey-frame');
 
         try {
-            const response = await fetch('monkey_data/monkey.svg');
+            const response = await fetch(`${this.getDevMode() ? '../' : '' }monkey_data/monkey.svg`);
             if (response.ok) {
                 const svgText = await response.text();
                 frame.innerHTML = svgText;
@@ -355,7 +359,7 @@ const ForkMonkey = {
             return this.svgCache[filename];
         }
 
-        const svgPath = 'monkey_evolution/${filename}';
+        const svgPath = `${this.getDevMode() ? '../' : '' }monkey_evolution/${filename}`;
 
         try {
             const response = await fetch(svgPath);

--- a/web/serve.py
+++ b/web/serve.py
@@ -7,9 +7,8 @@ import http.server
 import socketserver
 import webbrowser
 import os
+import argparse
 from pathlib import Path
-
-PORT = 8000
 
 class MyHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def end_headers(self):
@@ -20,6 +19,14 @@ class MyHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         super().end_headers()
 
 def main():
+    parser = argparse.ArgumentParser(description='Simple HTTP server for ForkMonkey web interface')
+    parser.add_argument('--port', type=int, default=8000, help='Port to run the server on')
+    parser.add_argument('--dev', choices=['true', 'false'], default='true', help='Enable development mode')
+    args = parser.parse_args()
+    
+    PORT = args.port
+    dev_mode = args.dev == 'true'
+    
     # Change to project root directory (parent of web/)
     project_root = Path(__file__).parent.parent
     os.chdir(project_root)
@@ -31,7 +38,7 @@ def main():
     with socketserver.TCPServer(("", PORT), Handler) as httpd:
         print(f"""
 ╔═══════════════════════════════════════════╗
-║     🐵 ForkMonkey Web Interface 🐵       ║
+║     🐵 ForkMonkey Web Interface 🐵        ║
 ╚═══════════════════════════════════════════╝
 
 Server running at: http://localhost:{PORT}
@@ -40,7 +47,8 @@ Press Ctrl+C to stop the server
         """)
         
         # Open browser to web/index.html
-        webbrowser.open(f'http://localhost:{PORT}/web/index.html')
+        dev_param = "?dev=true" if dev_mode else ""
+        webbrowser.open(f'http://localhost:{PORT}/web/index.html{dev_param}')
         
         try:
             httpd.serve_forever()


### PR DESCRIPTION
Hi,

my forkMonkey is deployed on [https://www.simonhaas.eu/forkMonkey/](https://www.simonhaas.eu/forkMonkey/)

The data could not be loaded because getBasePath caused it to try to load https://www.simonhaas.eu/monkey_data/monkey.svg instead of https://www.simonhaas.eu/forkMonkey/monkey_data/monkey.svg

This does NOT break github.io.

It is a bit messy because the folder monkey_data is in root during dev (start_web.sh) and one level down together with index.html in the build artifact generated by the github action.
